### PR TITLE
Allow check for updates without downloading them

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 > Atom's [`AutoUpdateManager`](https://github.com/atom/atom/blob/master/src/browser/auto-update-manager.coffee) class as a standalone module.
 
+This module is a wrapper around Electron's auto-updater that adds additional
+features like "check before you download" and some convenience methods.
+
+The main issue with Electron's auto-updater is that once you run `.checkForUpdates()`,
+there is no going back. If a newer version is available, it will go fetch the
+binary, download and install it. We don't want this behavior, instead we'd
+like to get user confirmation first before we download, and again before we
+restart the application.
+
+Therefore this module checks for a newer version first (with a `https.get()`
+request) and re-wires some of the existing events.
+
+Also read this [blog post][updater-blog] for more information on auto-updates
+for Electron apps.
+
 ## Example
 
 ```javascript
@@ -13,6 +28,9 @@ const autoUpdater = new AutoUpdateManager({
     icon_path: path.join(__dirname, '..', 'resources', 'mongodb-compass.png')
   })
   .on('update-available', () => {
+    autoUpdater.download();
+  })
+  .on('update-downloaded', () => {
     autoUpdater.install();
   })
   .check();
@@ -22,6 +40,8 @@ const autoUpdater = new AutoUpdateManager({
 
 Apache 2.0
 
+[electron-auto-updater]: https://github.com/electron/electron/blob/master/docs/api/auto-updater.md
+[updater-blog]: https://medium.com/@svilen/auto-updating-apps-for-windows-and-osx-using-electron-the-complete-guide-4aa7a50b904c#.q793uggoq
 [travis_img]: https://img.shields.io/travis/mongodb-js/hadron-auto-update-manager.svg
 [travis_url]: https://travis-ci.org/mongodb-js/hadron-auto-update-manager
 [npm_img]: https://img.shields.io/npm/v/hadron-auto-update-manager.svg

--- a/index.js
+++ b/index.js
@@ -68,7 +68,12 @@ function AutoUpdateManager(endpointURL, iconURL) {
   this.onUpdateError = _.bind(this.onUpdateError, this);
   this.onUpdateNotAvailable = _.bind(this.onUpdateNotAvailable, this);
   this.state = IdleState;
-  this.feedURL = `${endpointURL}/update?version=${this.version}&platform=${process.platform}&arch=${process.arch}`;
+  // TODO hack to get to the RELEASES file for windows updates
+  if (process.platform === 'win32') {
+    this.feedURL = `${endpointURL}/update/${process.platform}/${this.version}/RELEASES`;
+  } else {
+    this.feedURL = `${endpointURL}/update?version=${this.version}&platform=${process.platform}&arch=${process.arch}`;    
+  }
 
   process.nextTick(() => {
     this.setupAutoUpdater();

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const CheckingState = 'checking';
 const UpdateAvailableState = 'update-available';
 const DownloadingState = 'downloading';
 const UpdateDownloadedState = 'update-downloaded';
-const NoUpdateAvailableState = 'no-update-available';
+const NoUpdateAvailableState = 'update-not-available';
 const UnsupportedState = 'unsupported';
 const ErrorState = 'error';
 

--- a/index.js
+++ b/index.js
@@ -243,6 +243,7 @@ AutoUpdateManager.prototype.checkForUpdates = function(opts) {
     autoUpdateMgr.setState(UpdateAvailableState);
     autoUpdateMgr.emitEventToAllWindows('app:update-available');
   }).on('error', function(e) {
+    debug('error while checking for update', e);
     autoUpdateMgr.setState(ErrorState);
   });
 };
@@ -295,7 +296,8 @@ AutoUpdateManager.prototype.setState = function(state) {
   }
   this.state = state;
   debug('state is now', state);
-  return this.emit('state-changed', state);
+  this.emit('state-changed', state);
+  this.emit(state);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,25 +1,42 @@
 'use strict';
+
 /* eslint eqeqeq: 1, no-console:0 no-else-return: 1, no-cond-assign: 1, consistent-return: 1 */
 const path = require('path');
 const fs = require('fs');
-const electron = require('electron');
-const dialog = electron.dialog;
 const _ = require('lodash');
 const EventEmitter = require('events').EventEmitter;
-const autoUpdater = require('./auto-updater');
-const debug = require('debug')('hadron-auto-update-manager');
-const BrowserWindow = require('electron').BrowserWindow;
-const ENOSIGNATURE = 'Could not get code signature for running application';
-const app = electron.app;
+const https = require('https');
 
+const electron = require('electron');
+const BrowserWindow = electron.BrowserWindow;
+const dialog = electron.dialog;
+const app = electron.app;
+const autoUpdater = require('./auto-updater');
+
+// const debug = require('debug')('hadron-auto-update-manager');
+const debug = console.log;
+
+/*
+ * States of the auto updater state machine
+ */
 const IdleState = 'idle';
 const CheckingState = 'checking';
-const DownloadingState = 'downloading';
 const UpdateAvailableState = 'update-available';
+const DownloadingState = 'downloading';
+const UpdateDownloadedState = 'update-downloaded';
 const NoUpdateAvailableState = 'no-update-available';
 const UnsupportedState = 'unsupported';
 const ErrorState = 'error';
 
+const ENOSIGNATURE = 'Could not get code signature for running application';
+
+const HTTP_NO_CONTENT = 204;
+/**
+ * Constructor
+ *
+ * @param {String} endpointURL    URL to update server
+ * @param {String} iconURL        URL to icons
+ */
 function AutoUpdateManager(endpointURL, iconURL) {
   if (!endpointURL) {
     throw new TypeError('endpointURL is required!');
@@ -43,85 +60,13 @@ function AutoUpdateManager(endpointURL, iconURL) {
 }
 _.extend(AutoUpdateManager.prototype, EventEmitter.prototype);
 
-AutoUpdateManager.prototype.setupAutoUpdater = function() {
-  // Need to set error event handler before setting feedURL.
-  // Else we get the default node.js error event handling:
-  // die hard if errors are unhandled.
-  autoUpdater.on('error', (event, message) => {
-    if (message === ENOSIGNATURE) {
-      debug('no auto updater for unsigned builds');
-      return this.setState('unsupported');
-    }
-    debug('Error Downloading Update: ' + message);
-    return this.setState(ErrorState);
-  });
-
-  autoUpdater.setFeedURL(this.feedURL);
-
-  autoUpdater.on('checking-for-update', () => {
-    this.setState(CheckingState);
-  });
-
-  autoUpdater.on('update-not-available', () => {
-    this.setState(NoUpdateAvailableState);
-  });
-  autoUpdater.on('update-available', () => {
-    this.setState(DownloadingState);
-  });
-  autoUpdater.on('update-downloaded', (event, releaseNotes, releaseVersion) => {
-    this.releaseNotes = releaseNotes;
-    this.releaseVersion = releaseVersion;
-    this.setState(UpdateAvailableState);
-    this.emitUpdateAvailableEvent();
-  });
-};
 
 /**
-  * @api private
-  * @return {Boolean} Check scheduled?
-  */
-AutoUpdateManager.prototype.scheduleUpdateCheck = function() {
-  if (this.checkForUpdatesIntervalID) {
-    debug('Update check already scheduled');
-    return false;
-  }
-  var fourHours = 1000 * 60 * 60 * 4;
-  var checkForUpdates = this.checkForUpdates.bind(this, {
-    hidePopups: true
-  });
-  this.checkForUpdatesIntervalID = setInterval(checkForUpdates, fourHours);
-  checkForUpdates();
-  return true;
-},
-/**
-* @api private
-* @return {Boolean} Scheduled check cancelled?
-*/
-AutoUpdateManager.prototype.cancelScheduledUpdateCheck = function() {
-  if (this.checkForUpdatesIntervalID) {
-    clearInterval(this.checkForUpdatesIntervalID);
-    this.checkForUpdatesIntervalID = null;
-    debug('cancelled scheduled update check');
-    return true;
-  }
-  return false;
-};
-
-AutoUpdateManager.prototype.checkForUpdates = function(opts) {
-  debug('checkForUpdates with options', opts);
-  opts = opts || {};
-  if (!opts.hidePopups) {
-    autoUpdater.once('update-not-available', this.onUpdateNotAvailable);
-    autoUpdater.once('error', this.onUpdateError);
-  }
-  debug('checking for updates...');
-  autoUpdater.checkForUpdates();
-  return true;
-};
-
-/**
+ * Enable auto updates with interval checks (every 4 hours) for new updates.
+ *
  * @api public
- * @return {Boolean} Auto updates enabled?
+ * @return {Boolean}   returns true if auto updates were enabled, false if
+ *                     there was a problem or if they had been enabled already.
  */
 AutoUpdateManager.prototype.enable = function() {
   if (this.state === 'unsupported') {
@@ -132,19 +77,63 @@ AutoUpdateManager.prototype.enable = function() {
 };
 
 /**
+ * Disable auto updates (no more interval checks for new updates).
+ *
  * @api public
+ * @return {Boolean}  returns true if updates were disabled, false if they
+ *                    already had been disabled previously.
  */
 AutoUpdateManager.prototype.disable = function() {
-  this.cancelScheduledUpdateCheck();
+  return this.cancelScheduledUpdateCheck();
 };
 
 /**
+ * checks for updates now bypassing scheduled check.
+ *
  * @api public
- * @return {Boolean} Quit and install update?
+ * @return {Boolean}  returns false if there was a problem, true if check
+ *                    for updates happened.
+ */
+AutoUpdateManager.prototype.check = function() {
+  if (this.state === 'unsupported') {
+    debug('Updates are not supported.');
+    return false;
+  }
+  return this.checkForUpdates();
+};
+
+
+/**
+ * downloads the available update. Should only be called if in
+ * `update-available` state.
+ *
+ * @api public
+ * @return {Boolean}  returns false if there was a problem, true if check
+ *                    for updates happened.
+ */
+AutoUpdateManager.prototype.download = function() {
+  if (this.state === 'unsupported') {
+    debug('Updates are not supported.');
+    return false;
+  }
+  if (this.state !== UpdateAvailableState) {
+    debug('No update available.');
+    return false;
+  }
+  return this.checkAndDownload();
+};
+
+/**
+ * Install new update if it is available. Can only be executed if state is
+ * `download-available`.
+ *
+ * @api public
+ * @return {Boolean}   returns false if no update is abvailable, true if
+ *                     update is available and about to be installed.
  */
 AutoUpdateManager.prototype.install = function() {
-  if (this.state !== 'update-available') {
-    debug('No update to install');
+  if (this.state !== UpdateDownloadedState) {
+    debug('No update to install.');
     return false;
   }
 
@@ -157,46 +146,173 @@ AutoUpdateManager.prototype.install = function() {
 };
 
 /**
- * Check for updates now bypassing scheduled check.
- * @api public
- * @return {Boolean} Update check requested?
+ * Private APIs below.
  */
-AutoUpdateManager.prototype.check = function() {
-  if (this.state === 'unsupported') {
-    debug('Updates are not supported.');
-    return false;
-  }
-  return this.checkForUpdates();
+
+/**
+ * Sets up event handlers for auto updates.
+ * @api private
+ */
+AutoUpdateManager.prototype.setupAutoUpdater = function() {
+  // Need to set error event handler before setting feedURL.
+  // Else we get the default node.js error event handling:
+  // die hard if errors are unhandled.
+  autoUpdater.on('error', (event, message) => {
+    if (message === ENOSIGNATURE) {
+      debug('no auto updater for unsigned builds');
+      return this.setState(UnsupportedState);
+    }
+    debug('Error Downloading Update: ' + message);
+    return this.setState(ErrorState);
+  });
+
+  autoUpdater.setFeedURL(this.feedURL);
+
+  // autoUpdater.on('checking-for-update', () => {
+  //   this.setState(CheckingState);
+  // });
+
+  autoUpdater.on('update-not-available', () => {
+    this.setState(NoUpdateAvailableState);
+  });
+  autoUpdater.on('update-available', () => {
+    this.setState(DownloadingState);
+  });
+  autoUpdater.on('update-downloaded', (event, releaseNotes, releaseVersion) => {
+    this.releaseNotes = releaseNotes;
+    this.releaseVersion = releaseVersion;
+    this.setState(UpdateDownloadedState);
+    this.emitEventToAllWindows('app:update-downloaded');
+  });
 };
 
-AutoUpdateManager.prototype.emitUpdateAvailableEvent = function() {
+/**
+ * Sets interval timer to check for updates every 4 hours.
+ *
+ * @api private
+ * @return {Boolean}  returns true if the check has been scheduled, false if it
+ *                    was already scheduled previously.
+ */
+AutoUpdateManager.prototype.scheduleUpdateCheck = function() {
+  if (this.checkForUpdatesIntervalID) {
+    debug('Update check already scheduled');
+    return false;
+  }
+  var fourHours = 1000 * 60 * 60 * 4;
+  var checkForUpdates = this.checkForUpdates.bind(this, {
+    hidePopups: true
+  });
+  this.checkForUpdatesIntervalID = setInterval(checkForUpdates, fourHours);
+  this.checkForUpdates();
+  return true;
+};
+
+/**
+ * Cancels interval timer for update checks.
+ *
+ * @api private
+ * @return {Boolean}  returns true if the check was cancelled, false if it
+ *                    was not previously scheduled.
+ */
+AutoUpdateManager.prototype.cancelScheduledUpdateCheck = function() {
+  if (this.checkForUpdatesIntervalID) {
+    clearInterval(this.checkForUpdatesIntervalID);
+    this.checkForUpdatesIntervalID = null;
+    debug('cancelled scheduled update check');
+    return true;
+  }
+  return false;
+};
+
+/**
+ * check manually via https.get() if an update is available now, but
+ * don't download it yet.
+ *
+ * @return {Boolean}       returns true
+ */
+AutoUpdateManager.prototype.checkForUpdates = function(opts) {
+  var autoUpdateMgr = this;
+  autoUpdateMgr.setState(CheckingState);
+
+  // send request to server
+  https.get(this.feedURL, function(res) {
+    if (res.statusCode === HTTP_NO_CONTENT) {
+      // no updates available
+      return autoUpdateMgr.setState(NoUpdateAvailableState);
+    }
+    autoUpdateMgr.setState(UpdateAvailableState);
+    autoUpdateMgr.emitEventToAllWindows('app:update-available');
+  }).on('error', function(e) {
+    autoUpdateMgr.setState(ErrorState);
+  });
+};
+
+/**
+ * check if update available and automatically download it.
+ *
+ * @param  {Object} opts   options object, can have `hidePopups` boolean field
+ *                         to indicate whether a popup should be shown to give
+ *                         user feedback.
+ *
+ * @return {Boolean}       returns true
+ */
+AutoUpdateManager.prototype.checkAndDownload = function(opts) {
+  debug('checkForUpdates with options', opts);
+  opts = opts || {};
+  if (!opts.hidePopups) {
+    autoUpdater.once('update-not-available', this.onUpdateNotAvailable);
+    autoUpdater.once('error', this.onUpdateError);
+  }
+  debug('checking for updates...');
+  autoUpdater.checkForUpdates();
+  return true;
+};
+
+
+AutoUpdateManager.prototype.emitEventToAllWindows = function(evt, meta) {
   if (!this.releaseVersion) {
     return;
   }
   BrowserWindow.getAllWindows().forEach((_browserWindow) => {
-    debug('sending app:update-available');
+    debug('sending %s', evt);
     if (_browserWindow.webContents) {
-      _browserWindow.webContents.send('app:update-available', {
-        releaseVersion: this.releaseVersion,
-        releaseNotes: this.releaseNotes
-      });
+      _browserWindow.webContents.send(evt, meta);
     }
   });
 };
 
+/**
+ * Sets the current state of the auto updater state machine and emits
+ * a `state-changed` event. No-op if the state remains the same.
+ *
+ * @param  {String} state   new state
+ * @return {[type]}         returns true if the event had listeners, false
+ *                          otherwise.
+ */
 AutoUpdateManager.prototype.setState = function(state) {
   if (this.state === state) {
     return;
   }
   this.state = state;
   debug('state is now', state);
-  return this.emit('state-changed', this.state);
+  return this.emit('state-changed', state);
 };
 
+/**
+ * get current state of the auto updater state machine.
+ * @return {String}  current state.
+ */
 AutoUpdateManager.prototype.getState = function() {
   return this.state;
 };
 
+/**
+ * if opts.hidePopups was not set for `checkForUpdates`, this method
+ * will inform the user with a popup dialog that there was no update available.
+ *
+ * @return {Number}   returns the index of the clicked button, see
+ * https://github.com/electron/electron/blob/master/docs/api/dialog.md
+ */
 AutoUpdateManager.prototype.onUpdateNotAvailable = function() {
   debug('update not available', arguments);
   autoUpdater.removeListener('error', this.onUpdateError);
@@ -210,6 +326,14 @@ AutoUpdateManager.prototype.onUpdateNotAvailable = function() {
   });
 };
 
+/**
+ * if opts.hidePopups was not set for `checkForUpdates`, this method
+ * will inform the user with a popup dialog that there was an error checking
+ * for updates.
+ *
+ * @return {Number}   returns the index of the clicked button, see
+ * https://github.com/electron/electron/blob/master/docs/api/dialog.md
+ */
 AutoUpdateManager.prototype.onUpdateError = function(event, message) {
   debug('update error', arguments);
   autoUpdater.removeListener('update-not-available', this.onUpdateNotAvailable);

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ AutoUpdateManager.prototype.setupAutoUpdater = function() {
       return this.setState(UnsupportedState);
     }
     debug('Error Downloading Update: ' + message);
-    return this.setState(ErrorState);
+    return this.setState(ErrorState, message);
   });
 
   autoUpdater.setFeedURL(this.feedURL);
@@ -244,7 +244,7 @@ AutoUpdateManager.prototype.checkForUpdates = function(opts) {
     autoUpdateMgr.emitEventToAllWindows('app:update-available');
   }).on('error', function(e) {
     debug('error while checking for update', e);
-    autoUpdateMgr.setState(ErrorState);
+    autoUpdateMgr.setState(ErrorState, e);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "devDependencies": {
     "electron-mocha": "^1.0.2",
     "electron-prebuilt": "^0.37.5",
-    "eslint-config-mongodb-js": "^1.0.6",
+    "eslint-config-mongodb-js": "^2.0.0",
+    "mock-require": "^1.3.0",
     "mongodb-js-fmt": "^0.0.3",
     "xvfb-maybe": "^0.1.3"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,12 @@
 'use strict';
 
-let AutoUpdateManager = require('../');
 const assert = require('assert');
 const electronVersion = require('electron-prebuilt/package.json').version;
+const mock = require('mock-require');
+const debug = require('debug')('hadron-auto-update-manager:test');
+let AutoUpdateManager = require('../');
+
+
 
 describe('hadron-auto-update-manager', () => {
   it('should have an export', () => {
@@ -17,5 +21,70 @@ describe('hadron-auto-update-manager', () => {
     assert.equal(autoUpdateManager.version, electronVersion);
     assert.equal(autoUpdateManager.feedURL,
       `https://hadron-endpoint.herokuapp.com/update?version=${electronVersion}&platform=${process.platform}&arch=${process.arch}`);
+  });
+
+  describe('checkForUpdates', function() {
+    context('with mocked https module', function() {
+
+      context('does not have new update', function() {
+        before(function() {
+          mock('https', {
+            get: function(options, callback) {
+              setTimeout(callback.bind(null, {statusCode: 204}), 100);
+              return {
+                on: function() {}
+              };
+            }
+          });
+          AutoUpdateManager = mock.reRequire('../');
+        });
+
+        after(function() {
+          mock.stop('https');
+          AutoUpdateManager = mock.reRequire('../');
+        });
+
+        it('should eventually go into `no-update-available` state', function(done) {
+          const endpoint = 'https://hadron-endpoint.herokuapp.com';
+          const autoUpdateManager = new AutoUpdateManager(endpoint);
+          autoUpdateManager.on('state-changed', function(state) {
+            if (state === 'no-update-available') {
+              done();
+            }
+          });
+          autoUpdateManager.checkForUpdates();
+        });
+      });
+
+      context('has new update', function() {
+        before(function() {
+          mock('https', {
+            get: function(options, callback) {
+              setTimeout(callback.bind(null, {statusCode: 200}), 100);
+              return {
+                on: function() {}
+              };
+            }
+          });
+          AutoUpdateManager = mock.reRequire('../');
+        });
+
+        after(function() {
+          mock.stop('https');
+          AutoUpdateManager = mock.reRequire('../');
+        });
+
+        it('should eventually go into `update-available` state', function(done) {
+          const endpoint = 'https://hadron-endpoint.herokuapp.com';
+          const autoUpdateManager = new AutoUpdateManager(endpoint);
+          autoUpdateManager.on('state-changed', function(state) {
+            if (state === 'update-available') {
+              done();
+            }
+          });
+          autoUpdateManager.checkForUpdates();
+        });
+      });
+    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,7 +52,7 @@ describe('hadron-auto-update-manager', () => {
               done();
             }
           });
-          autoUpdateManager.checkForUpdates();
+          autoUpdateManager.checkForUpdates({hidePopups: true});
         });
       });
 
@@ -82,7 +82,7 @@ describe('hadron-auto-update-manager', () => {
               done();
             }
           });
-          autoUpdateManager.checkForUpdates();
+          autoUpdateManager.checkForUpdates({hidePopups: true});
         });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,11 +44,11 @@ describe('hadron-auto-update-manager', () => {
           AutoUpdateManager = mock.reRequire('../');
         });
 
-        it('should eventually go into `no-update-available` state', function(done) {
+        it('should eventually go into `update-not-available` state', function(done) {
           const endpoint = 'https://hadron-endpoint.herokuapp.com';
           const autoUpdateManager = new AutoUpdateManager(endpoint);
           autoUpdateManager.on('state-changed', function(state) {
-            if (state === 'no-update-available') {
+            if (state === 'update-not-available') {
               done();
             }
           });


### PR DESCRIPTION
The main issue with Electron's auto-updater is that once you run `.checkForUpdates()`, there is no going back. If a newer version is available, it will go fetch the binary, download and install it. We don't want this behavior, instead we'd like to get user confirmation first before we download, and again before we
restart the application.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/hadron-auto-update-manager/2)

<!-- Reviewable:end -->
